### PR TITLE
詳細画面(仮)終了

### DIFF
--- a/public/js/show.js
+++ b/public/js/show.js
@@ -1,0 +1,49 @@
+//show.blade.phpでの変数を使える。確認済み
+// Initialize and add the map
+function initMap() {
+//ジオコードオブジェクトapiへの問い合わせをするためのオブジェクト
+var geocoder = new google.maps.Geocoder();
+var address = point_address;
+ if (geocoder) {
+ geocoder.geocode( { 'address': address,'region': 'jp'},
+    function(results, status) {
+  if (status == google.maps.GeocoderStatus.OK) {
+    map.setCenter(results[0].geometry.location);
+
+   var bounds = new google.maps.LatLngBounds();
+   for (var r in results) {
+    if (results[r].geometry) {
+     var latlng = results[r].geometry.location;
+     bounds.extend(latlng);
+    new google.maps.Marker({
+    position: latlng,map: map
+    });
+
+    point_lat = latlng.lat();
+    point_lng = latlng.lng();
+
+    }
+   }
+   //map.fitBounds(bounds);
+   }else{
+    alert("Geocode 取得に失敗しました reason: "
+         + status);
+   }
+  });
+ }
+  
+  // lat、lngを変数で指定できるようにする
+  const uluru = { lat: point_lat, lng: point_lng};
+  // The map, centered at Uluru
+  const map = new google.maps.Map(document.getElementById("map"), {
+    zoom: 13,
+    center: uluru,
+  });
+  // The marker, positioned at Uluru
+  const marker = new google.maps.Marker({
+    position: uluru,
+    map: map,
+  });
+}
+
+window.initMap = initMap;

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -15,7 +15,11 @@
 
     </head>
     <body>
-
+    <script>
+    let point_lat=35.604577;
+    let point_lng=140.123196;
+    let point_address='{{$post->address}}'
+    </script>
     <!-- maps javascript api テスト --> 
     <div id="map"></div>
     <div class="content">
@@ -37,7 +41,7 @@
     <!-- jQueryの読み込み-->
     <script src="https://code.jquery.com/jquery-3.5.1.js" integrity="sha256-QWo7LDvxbWT2tbbQ97B53yJnYU3WhH/C8ycbRAkjPDc=" crossorigin="anonymous"></script>
     
-    <script type="module" src="{{ asset('/js/index.js')}}"></script>
+    <script type="module" src="{{ asset('/js/show.js')}}"></script>
     <script src="{{ asset('/js/setLocation.js') }}"></script> 
 
     <script


### PR DESCRIPTION
仮の詳細画面の実装。
卒業までの時間が無いので、住所と説明、地図のみの表示を行っています。
currentLocation.blade.phpのマップの吹き出しからは飛べないです。
マップしたのリンクから詳細画面へ行けるようになっています。